### PR TITLE
Correctie op links en teksten

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # Haal Centraal BGT bevragen
 
+## Let op! Deze API wordt (nog) niet door het Kadaster aangeboden!
+
 Voor deze API worden op dit moment user stories bij gemeenten verzameld.
 
-## Direct uitproberen?
+## Direct aan de slag?
 Er zijn nog geen specificaties.
 
 ## Bronnen
 
-* [Productvisie Haal Centraal](https://vng-realisatie.github.io/Haal-Centraal)
-* [API Design Visie](https://github.com/Geonovum/KP-APIs/tree/master/Werkgroep%20Design%20Visie)
+* [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md)
 * [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/)
 * [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/)
-* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/BGT/)
+* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BGT)
 
 ## Contact
 
-* Product Owner: Cathy Dingemanse, [c.dingemanse@comites.nl](mailto:c.dingemanse@comites.nl)
+<!--* Product Owner: Cathy Dingemanse, [c.dingemanse@comites.nl](mailto:c.dingemanse@comites.nl)
 * Designer: Johan Boer, [johan.boer@vng.nl](mailto:johan.boer@vng.nl)
 * Designer: Robert Melskens, [robert.melskens@vng.nl](mailto:robert.melskens@vng.nl)
 * Customer zero: Melvin Lee, [melvin.lee@iswish.nl](mailto:melvin.lee@iswish.nl)
-* Tester: Frank Samwel, [frank.samwel@denhaag.nl](mailto:frank.samwel@denhaag.nl)
+* Tester: Frank Samwel, [frank.samwel@denhaag.nl](mailto:frank.samwel@denhaag.nl)-->
+[VNG Ondersteuning standaarden](mailto:ondersteuning.standaarden@vng.nl)
 
 ## Licentie
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Haal Centraal BGT bevragen
 
-## Let op! Deze API wordt tot nader order niet door het Kadaster aangeboden!
+**Deze API wordt tot nader order niet door het Kadaster aangeboden en wordt daarom gearchiveerd**
 
 Voor deze API worden op dit moment user stories bij gemeenten verzameld.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Haal Centraal BGT bevragen
 
-## Let op! Deze API wordt (nog) niet door het Kadaster aangeboden!
+## Let op! Deze API wordt tot nader order niet door het Kadaster aangeboden!
 
 Voor deze API worden op dit moment user stories bij gemeenten verzameld.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,26 +4,28 @@ title: Haal Centraal BGT bevragen
 ---
 # Haal Centraal BGT bevragen
 
+## Let op! Deze API wordt (nog) niet door het Kadaster aangeboden!
+
 Voor deze API worden op dit moment user stories bij gemeenten verzameld.
 
-## Direct uitproberen?
+## Direct aan de slag?
 Er zijn nog geen specificaties.
 
 ## Bronnen
 
-* [Productvisie Haal Centraal](https://vng-realisatie.github.io/Haal-Centraal){:target="_blank" rel="noopener"}
-* [API Design Visie](https://github.com/Geonovum/KP-APIs/tree/master/Werkgroep%20Design%20Visie){:target="_blank" rel="noopener"}
+* [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md){:target="_blank" rel="noopener"}
 * [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/){:target="_blank" rel="noopener"}
 * [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/){:target="_blank" rel="noopener"}
-* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/BGT){:target="_blank" rel="noopener"}
+* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BGT){:target="_blank" rel="noopener"}
 
 ## Contact
 
-* Product Owner: Cathy Dingemanse, [c.dingemanse@comites.nl](mailto:c.dingemanse@comites.nl)
+<!--* Product Owner: Cathy Dingemanse, [c.dingemanse@comites.nl](mailto:c.dingemanse@comites.nl)
 * Designer: Johan Boer, [johan.boer@vng.nl](mailto:johan.boer@vng.nl)
 * Designer: Robert Melskens, [robert.melskens@vng.nl](mailto:robert.melskens@vng.nl)
 * Customer zero: Melvin Lee, [melvin.lee@iswish.nl](mailto:melvin.lee@iswish.nl)
-* Tester: Frank Samwel, [frank.samwel@denhaag.nl](mailto:frank.samwel@denhaag.nl)
+* Tester: Frank Samwel, [frank.samwel@denhaag.nl](mailto:frank.samwel@denhaag.nl)-->
+[VNG Ondersteuning standaarden](mailto:ondersteuning.standaarden@vng.nl)
 
 ## Licentie
 


### PR DESCRIPTION
O.a.:

* README.md
    - Inhoud gelijk gemaakt aan 'index.md' (main pagina van GitHub Pages);
* index.md (main pagina van GitHub Pages)
  - PO en Berichtdesigner in Contact sectie vervangen door link naar standaarden.ondersteuning@vng.nl
  - Waarschuwing geplaatst dat de API (nog) niet wordt aangeboden door het Kadaster. <br/><br/>We kunnen nog overwegen om:
    - Tekst in de README uit te becommentariëren maar i.i.g. de link naar de API specificaties in Swagger.
    - Repository te archiveren.
  - De link 'Stelselcatalogus' werkte niet meer. Deze verwees naar:<br/><br/>*https://www.stelselcatalogus.nl/registraties/BGT/*<br/><br/>maar moet waarschijnlijk verwijzen naar:<br/><br/>*https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BGT*<br/><br/>Dit heb ik in deze PR aangepast maar graag even aangeven of dit klopt;


**LET OP**
- [ ] Na mergen in main branch ook develop branch gelijk trekken.